### PR TITLE
ci: fix venv regression

### DIFF
--- a/.github/workflows/build_venv.yaml
+++ b/.github/workflows/build_venv.yaml
@@ -11,6 +11,8 @@ jobs:
         python_version: ['3.11']
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
       - name: Install required libraries
         run: sudo apt install -y libsystemd-dev
       - name: Set env


### PR DESCRIPTION
In #8 I forgot to add a checkout step to the workflow, which is now required since the standalone action-python-venv-package's `checkout_repository` now defaults to `"false"`.
